### PR TITLE
Add configurable Whisper runtime options

### DIFF
--- a/transcribe.py
+++ b/transcribe.py
@@ -1,29 +1,124 @@
 """Utilities for transcribing recorded Discord sessions with metadata."""
 
-import os
-import json
-import sys
+from __future__ import annotations
+
 import glob
-import pathlib
+import json
+import os
 import re
+import sys
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Optional
+from pathlib import Path
+from typing import Dict, Optional
+
 from faster_whisper import WhisperModel
 
-# --- konfiguracja ---
-SESSION_DIR = os.environ.get("SESSION_DIR")
-RECORDINGS_DIR = os.environ.get("RECORDINGS_DIR", "/app/recordings")
-MODEL_SIZE = os.environ.get("WHISPER_MODEL", "small")
 
-def pick_latest_session(recordings_dir: str) -> str:
+@dataclass
+class TranscribeConfig:
+    """Runtime configuration for whisper transcription."""
+
+    recordings_dir: Path
+    output_dir: Path
+    session_dir: Optional[Path]
+    model_size: str
+    device: str
+    compute_type: str
+    beam_size: int
+    language: str
+    vad_filter: bool
+    vad_parameters: Dict[str, int]
+
+
+def _strtobool_env(value: Optional[str], default: bool) -> bool:
+    if value is None:
+        return default
+    return value.strip() not in {"0", "false", "False"}
+
+
+def _parse_int(value: Optional[str], default: int) -> int:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def _cuda_available() -> bool:
+    try:
+        import torch  # type: ignore
+
+        return bool(getattr(torch.cuda, "is_available", lambda: False)())
+    except ImportError:
+        try:
+            import ctranslate2  # type: ignore
+
+            return bool(getattr(ctranslate2, "has_cuda_device", lambda: False)())
+        except ImportError:
+            return False
+
+
+def load_config() -> TranscribeConfig:
+    """Load configuration from environment variables."""
+
+    recordings_dir = Path(os.environ.get("RECORDINGS_DIR", "./recordings")).expanduser().resolve()
+    output_dir = Path(os.environ.get("OUTPUT_DIR", "./out")).expanduser().resolve()
+    session_env = os.environ.get("SESSION_DIR")
+    session_dir = None
+    if session_env:
+        raw_session = Path(session_env).expanduser()
+        session_dir = raw_session if raw_session.is_absolute() else recordings_dir / raw_session
+
+    requested_device = os.environ.get("WHISPER_DEVICE", "cuda").lower()
+    model_size = os.environ.get("WHISPER_MODEL", "large-v3")
+    compute_type = os.environ.get("WHISPER_COMPUTE", "int8_float16").lower()
+
+    valid_compute_types = {"int8_float16", "int8", "float16"}
+    if compute_type not in valid_compute_types:
+        print(
+            f"[!] Nieznany WHISPER_COMPUTE={compute_type}, używam domyślnego int8_float16.",
+            file=sys.stderr,
+        )
+        compute_type = "int8_float16"
+
+    beam_size = max(1, _parse_int(os.environ.get("WHISPER_BEAM"), 5))
+    language = os.environ.get("WHISPER_LANG", "pl")
+    vad_filter = _strtobool_env(os.environ.get("WHISPER_VAD"), True)
+    vad_parameters = {"min_silence_duration_ms": 500, "padding_duration_ms": 120}
+
+    if requested_device == "cuda" and not _cuda_available():
+        print(
+            "[!] CUDA nie jest dostępna, przełączam na CPU z modelem medium i compute_type int8.",
+            file=sys.stderr,
+        )
+        requested_device = "cpu"
+        model_size = "medium"
+        compute_type = "int8"
+
+    return TranscribeConfig(
+        recordings_dir=recordings_dir,
+        output_dir=output_dir,
+        session_dir=session_dir,
+        model_size=model_size,
+        device="cuda" if requested_device == "cuda" else "cpu",
+        compute_type=compute_type,
+        beam_size=beam_size,
+        language=language,
+        vad_filter=vad_filter,
+        vad_parameters=vad_parameters,
+    )
+
+def pick_latest_session(recordings_dir: Path) -> Optional[Path]:
     """Return the newest recording session directory in ``recordings_dir``."""
 
     sessions = sorted(
-        [p for p in pathlib.Path(recordings_dir).glob("*") if p.is_dir()],
+        (p for p in recordings_dir.glob("*") if p.is_dir()),
         key=lambda p: p.stat().st_mtime,
         reverse=True,
     )
-    return str(sessions[0]) if sessions else ""
+    return sessions[0] if sessions else None
 
 def norm_text(t: str) -> str:
     """Normalise text for fuzzy duplicate detection."""
@@ -45,30 +140,67 @@ def parse_iso_to_epoch(value: Optional[str]) -> Optional[float]:
     except ValueError:
         return None
 
+def _resolve_session_path(config: TranscribeConfig) -> Optional[Path]:
+    if config.session_dir:
+        if config.session_dir.is_dir():
+            return config.session_dir.resolve()
+        candidate = (config.recordings_dir / config.session_dir.name).resolve()
+        return candidate if candidate.is_dir() else None
+    return pick_latest_session(config.recordings_dir)
+
+
+def _relative_session_path(config: TranscribeConfig, session_dir: Path) -> Path:
+    try:
+        return session_dir.relative_to(config.recordings_dir)
+    except ValueError:
+        return Path(session_dir.name)
+
+
 def main():
     """Generate per-user and global transcripts for the selected session."""
 
-    session_dir = SESSION_DIR or pick_latest_session(RECORDINGS_DIR)
+    config = load_config()
+
+    if not config.recordings_dir.exists():
+        print(f"[!] Brak katalogu nagrań: {config.recordings_dir}")
+        sys.exit(1)
+
+    session_dir = _resolve_session_path(config)
     if not session_dir:
         print("Brak sesji do transkrypcji.")
         sys.exit(1)
 
-    raw_dir = os.path.join(session_dir, "raw")
-    out_dir = os.path.join(session_dir, "transcripts")
-    os.makedirs(out_dir, exist_ok=True)
+    raw_dir = session_dir / "raw"
+    if not raw_dir.exists():
+        print(f"[!] Brak katalogu z plikami RAW: {raw_dir}")
+        sys.exit(1)
 
-    files = sorted(glob.glob(os.path.join(raw_dir, "*.wav")))
+    output_session_dir = config.output_dir / _relative_session_path(config, session_dir)
+    out_dir = output_session_dir / "transcripts"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    files = sorted(glob.glob(str(raw_dir / "*.wav")))
     files = [f for f in files if os.path.getsize(f) >= 1024]
     if not files:
         print(f"[!] Brak sensownych plików WAV w {raw_dir} (>=1KB).")
         sys.exit(0)
 
     print(f"[i] Sesja: {session_dir}")
-    print(f"[i] Model: {MODEL_SIZE}")
+    print(
+        "[i] Konfiguracja: model={model} device={device} compute_type={compute} "
+        "beam={beam} language={lang} vad={vad}".format(
+            model=config.model_size,
+            device=config.device,
+            compute=config.compute_type,
+            beam=config.beam_size,
+            lang=config.language,
+            vad=int(config.vad_filter),
+        )
+    )
 
-    manifest_path = os.path.join(session_dir, "manifest.json")
+    manifest_path = session_dir / "manifest.json"
     manifest_start_iso = None
-    if os.path.exists(manifest_path):
+    if manifest_path.exists():
         try:
             with open(manifest_path, "r", encoding="utf-8") as f:
                 manifest = json.load(f)
@@ -76,9 +208,9 @@ def main():
         except (json.JSONDecodeError, OSError) as exc:
             print(f"[!] Nie udało się odczytać manifestu {manifest_path}: {exc}")
 
-    model = WhisperModel(MODEL_SIZE, device="cpu", compute_type="int8")
+    model = WhisperModel(config.model_size, device=config.device, compute_type=config.compute_type)
 
-    buckets = {}
+    buckets: Dict[str, list[str]] = {}
     for f in files:
         name = os.path.basename(f)
         user_prefix = name.rsplit("_seg", 1)[0]
@@ -98,11 +230,14 @@ def main():
             try:
                 file_t0 = os.path.getmtime(wav)
                 print(f"[file] {os.path.basename(wav)} mtime={file_t0}")
-                segments, _info = model.transcribe(
-                    wav,
-                    vad_filter=True,
-                    vad_parameters=dict(min_silence_duration_ms=500),
+                transcribe_kwargs = dict(
+                    beam_size=config.beam_size,
+                    language=config.language,
+                    vad_filter=config.vad_filter,
                 )
+                if config.vad_filter:
+                    transcribe_kwargs["vad_parameters"] = config.vad_parameters
+                segments, _info = model.transcribe(wav, **transcribe_kwargs)
                 for seg in segments:
                     pseudo_t = file_t0 + float(seg.start)
                     print(f"  [seg] {wav} {seg.start:.2f}-{seg.end:.2f}s :: {seg.text.strip()}")
@@ -170,7 +305,7 @@ def main():
         manifest_start_iso = datetime.fromtimestamp(session_t0, tz=timezone.utc).isoformat().replace("+00:00", "Z")
 
     timeline_payload = {
-        "session_dir": session_dir,
+        "session_dir": str(session_dir),
         "session_start_iso": manifest_start_iso,
         "generated_at": datetime.utcnow().replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z"),
         "segments": [],
@@ -198,20 +333,20 @@ def main():
     for user_data in user_payloads:
         for seg in user_data["segments"]:
             seg.pop("session_epoch", None)
-        user_json_path = os.path.join(out_dir, f"{user_data['user']}.json")
+        user_json_path = out_dir / f"{user_data['user']}.json"
         with open(user_json_path, "w", encoding="utf-8") as f:
             json.dump(user_data, f, ensure_ascii=False, indent=2)
         print(f"[✓] Zapisano: {user_json_path} ({len(user_data['segments'])} segmentów)")
 
-    conversation_path = os.path.join(out_dir, "conversation.json")
+    conversation_path = out_dir / "conversation.json"
     with open(conversation_path, "w", encoding="utf-8") as f:
         json.dump(timeline_payload, f, ensure_ascii=False, indent=2)
     print(f"[✓] Globalna oś czasu: {conversation_path} ({len(timeline_payload['segments'])} wpisów)")
 
-    index_path = os.path.join(out_dir, "index.json")
+    index_path = out_dir / "index.json"
     with open(index_path, "w", encoding="utf-8") as f:
         json.dump({
-            "session_dir": session_dir,
+            "session_dir": str(session_dir),
             "generated_at": datetime.utcnow().isoformat() + "Z",
             "items": summary_index,
             "conversation_segments": len(timeline_payload["segments"]),


### PR DESCRIPTION
## Summary
- load Whisper runtime configuration from environment variables with GPU fallback to CPU
- enforce decoding defaults and VAD parameters while logging chosen runtime
- write transcripts into a configurable output directory alongside session metadata

## Testing
- python -m compileall transcribe.py

------
https://chatgpt.com/codex/tasks/task_e_68e38ac479988321995f8e3d8718b741