### PR TITLE
chore: clean environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Discord bot configuration
+DISCORD_TOKEN=your-discord-bot-token
+SESSION_PREFIX=session
+RECORDINGS_DIR=./recordings
+
+# Whisper transcription settings
+OUTPUT_DIR=./out
+SESSION_DIR=
+WHISPER_MODEL=large-v3
+WHISPER_DEVICE=cuda
+WHISPER_COMPUTE=int8_float16
+WHISPER_BEAM=5
+WHISPER_LANG=pl
+WHISPER_VAD=true
+SANITIZE_LOWER_NOISE=false

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
+# Dependencies
 node_modules/
+
+# Environment files
 .env
+
+# Python artifacts
 __pycache__/
 *.pyc
-recordings/
+
+# Runtime output
+/recordings/
+/out/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,22 +2,36 @@ services:
   discord-recorder:
     build: .
     container_name: discord-recorder
+    env_file:
+      - .env
     environment:
-      - DISCORD_TOKEN=MTQyMjE2MjM4MjM5ODE2NTAxMg.GHfZa7.44SM-D8jxZnD_vCv7o3Y0ViOGsHe5WJTB_aYZM
-      - RECORDINGS_DIR=${RECORDINGS_DIR}
-      - SESSION_PREFIX=${SESSION_PREFIX}
+      DISCORD_TOKEN: ${DISCORD_TOKEN:?Set DISCORD_TOKEN in .env}
+      RECORDINGS_DIR: /app/recordings
+      SESSION_PREFIX: ${SESSION_PREFIX:-session}
     volumes:
-      - ./recordings:/app/recordings
+      - ${RECORDINGS_DIR:-./recordings}:/app/recordings
     restart: unless-stopped
+
   transcriber:
     image: python:3.11-slim
     container_name: discord-transcriber
     working_dir: /app
+    env_file:
+      - .env
+    environment:
+      RECORDINGS_DIR: /app/recordings
+      OUTPUT_DIR: /app/out
+      WHISPER_MODEL: ${WHISPER_MODEL:-large-v3}
+      WHISPER_DEVICE: ${WHISPER_DEVICE:-cuda}
+      WHISPER_COMPUTE: ${WHISPER_COMPUTE:-int8_float16}
+      WHISPER_BEAM: ${WHISPER_BEAM:-5}
+      WHISPER_LANG: ${WHISPER_LANG:-pl}
+      WHISPER_VAD: ${WHISPER_VAD:-true}
+      SANITIZE_LOWER_NOISE: ${SANITIZE_LOWER_NOISE:-false}
     volumes:
       - ./:/app
-      - ./recordings:/app/recordings
-    environment:
-      - RECORDINGS_DIR=/app/recordings
-      - WHISPER_MODEL=small
-    command: bash -lc "pip install --no-cache-dir faster-whisper && python transcribe.py"
+      - ${RECORDINGS_DIR:-./recordings}:/app/recordings
+      - ${OUTPUT_DIR:-./out}:/app/out
+    command: >-
+      bash -lc "pip install --no-cache-dir faster-whisper && python transcribe.py"
     restart: "no"


### PR DESCRIPTION
## Summary
- add a documented .env.example template for Discord and Whisper settings
- scrub the hard-coded Discord token and source env vars through docker-compose
- tighten the gitignore to cover env files and runtime output directories

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e38ec2f7ec8321afcfb7be42028071