### PR TITLE
feat: connect GUI actions to backend services

### DIFF
--- a/tests/ui/test_sessions.py
+++ b/tests/ui/test_sessions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from ui.services.sessions import discover_sessions
+from ui.services.sessions import discover_sessions, validate_manifest
 
 
 def test_discover_sessions(tmp_path: Path) -> None:
@@ -25,3 +25,51 @@ def test_discover_sessions(tmp_path: Path) -> None:
     assert summary.channel == "general"
     assert summary.users == ["alice", "bob"]
     assert summary.duration == 123.4
+
+
+def test_validate_manifest_success(tmp_path: Path) -> None:
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    audio_path = session_dir / "alice.wav"
+    audio_path.write_bytes(b"data")
+    out_dir = tmp_path / "out" / "session" / "transcripts"
+    out_dir.mkdir(parents=True)
+    (out_dir / "user.json").write_text("{}", encoding="utf8")
+    (out_dir / "user.srt").write_text("", encoding="utf8")
+    (out_dir / "user.vtt").write_text("", encoding="utf8")
+    manifest = {
+        "transcripts": {
+            "alice": {
+                "wav_path": ["alice.wav"],
+                "json_path": "../out/session/transcripts/user.json",
+                "srt_path": "../out/session/transcripts/user.srt",
+                "vtt_path": "../out/session/transcripts/user.vtt",
+            }
+        }
+    }
+    (session_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf8")
+
+    issues = validate_manifest(session_dir)
+    assert any(issue.level == "info" for issue in issues)
+    assert all(issue.level == "info" for issue in issues)
+
+
+def test_validate_manifest_missing_files(tmp_path: Path) -> None:
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    manifest = {
+        "transcripts": {
+            "alice": {
+                "wav_path": ["missing.wav"],
+                "json_path": "../out/session/transcripts/user.json",
+                "srt_path": "",
+                "vtt_path": None,
+            }
+        }
+    }
+    (session_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf8")
+
+    issues = validate_manifest(session_dir)
+    levels = {issue.level for issue in issues}
+    assert "error" in levels
+    assert "warning" in levels

--- a/ui/services/align.py
+++ b/ui/services/align.py
@@ -1,15 +1,211 @@
 """Alignment related helpers."""
 from __future__ import annotations
 
+import json
+import os
+import queue
+import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List
+from threading import Event, Thread
+from typing import Iterable, List, Sequence
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
 @dataclass(slots=True)
 class AlignItem:
     path: Path
     selected: bool = True
+
+
+@dataclass(slots=True)
+class AlignmentMessage:
+    level: str
+    message: str
+    candidate: Path | None = None
+
+
+class AlignmentWorker(Thread):
+    """Background worker executing ``align.py`` for selected candidates."""
+
+    def __init__(
+        self,
+        candidates: Sequence[AlignItem],
+        recordings_dir: Path,
+        output_dir: Path,
+        queue_: "queue.Queue[AlignmentMessage]",
+        *,
+        diarization_token: str | None = None,
+    ) -> None:
+        super().__init__(daemon=True)
+        self._candidates = list(candidates)
+        self._recordings_dir = recordings_dir
+        self._output_dir = output_dir
+        self._queue = queue_
+        self._token = diarization_token
+        self._stop_event = Event()
+        self._running = Event()
+        self._current_process: subprocess.Popen[str] | None = None
+
+    # ------------------------------------------------------------------
+    def run(self) -> None:  # pragma: no cover - threaded worker
+        self._running.set()
+        try:
+            for item in self._candidates:
+                if self._stop_event.is_set():
+                    break
+                self._queue.put(
+                    AlignmentMessage(level="info", message=f"Start align dla {item.path.name}", candidate=item.path)
+                )
+                payload = self._load_segments(item.path)
+                if payload is None:
+                    continue
+                audio_path = self._resolve_audio_path(item.path, payload)
+                if audio_path is None:
+                    continue
+                output_path = item.path.with_suffix(".aligned.json")
+                if self._stop_event.is_set():
+                    break
+                self._execute_alignment(audio_path, item.path, output_path)
+        finally:
+            final_state = "stopped" if self._stop_event.is_set() else "done"
+            self._queue.put(AlignmentMessage(level="state", message=final_state))
+            self._running.clear()
+
+    # ------------------------------------------------------------------
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._current_process and self._current_process.poll() is None:
+            self._current_process.terminate()
+
+    # ------------------------------------------------------------------
+    @property
+    def is_running(self) -> bool:
+        return self._running.is_set()
+
+    # ------------------------------------------------------------------
+    def _load_segments(self, path: Path) -> dict | None:
+        try:
+            payload = json.loads(path.read_text(encoding="utf8"))
+        except json.JSONDecodeError as exc:
+            self._queue.put(
+                AlignmentMessage(
+                    level="error", message=f"Nie mogę odczytać JSON ({exc})", candidate=path
+                )
+            )
+            return None
+        if "segments" not in payload:
+            self._queue.put(
+                AlignmentMessage(level="warning", message="Brak pola 'segments'", candidate=path)
+            )
+            return None
+        return payload
+
+    # ------------------------------------------------------------------
+    def _resolve_audio_path(self, json_path: Path, payload: dict) -> Path | None:
+        raw_files = payload.get("raw_files")
+        audio_candidates: Iterable[str]
+        if isinstance(raw_files, list):
+            audio_candidates = [str(item) for item in raw_files if isinstance(item, (str, Path))]
+        elif isinstance(raw_files, str):
+            audio_candidates = [raw_files]
+        else:
+            audio_candidates = []
+
+        audio_candidates = list(audio_candidates)
+        if not audio_candidates:
+            self._queue.put(
+                AlignmentMessage(level="warning", message="Brak informacji o plikach audio", candidate=json_path)
+            )
+            return None
+        if len(audio_candidates) > 1:
+            self._queue.put(
+                AlignmentMessage(
+                    level="warning",
+                    message="Wiele plików audio w JSON – wykorzystuję pierwszy wpis.",
+                    candidate=json_path,
+                )
+            )
+        session_relative = self._session_relative_path(json_path)
+        audio_path = (self._recordings_dir / session_relative / Path(audio_candidates[0])).resolve()
+        if not audio_path.exists():
+            self._queue.put(
+                AlignmentMessage(
+                    level="error",
+                    message=f"Brak pliku audio: {audio_candidates[0]}",
+                    candidate=json_path,
+                )
+            )
+            return None
+        return audio_path
+
+    # ------------------------------------------------------------------
+    def _session_relative_path(self, json_path: Path) -> Path:
+        try:
+            relative = json_path.relative_to(self._output_dir)
+        except ValueError:
+            return Path()
+        parts = list(relative.parts)
+        if len(parts) <= 2:
+            return Path()
+        return Path(*parts[:-2])
+
+    # ------------------------------------------------------------------
+    def _execute_alignment(self, audio_path: Path, json_path: Path, output_path: Path) -> None:
+        command = [
+            sys.executable,
+            "align.py",
+            str(audio_path),
+            str(json_path),
+            "--output",
+            str(output_path),
+        ]
+        env = os.environ.copy()
+        if self._token:
+            env.setdefault("PYANNOTE_AUTH_TOKEN", self._token)
+        try:
+            self._current_process = subprocess.Popen(
+                command,
+                cwd=str(PROJECT_ROOT),
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        except OSError as exc:
+            self._queue.put(
+                AlignmentMessage(level="error", message=f"Nie mogę uruchomić align.py: {exc}", candidate=json_path)
+            )
+            return
+
+        stdout, stderr = self._current_process.communicate()
+        return_code = self._current_process.returncode
+        self._current_process = None
+        if stdout:
+            for line in stdout.splitlines():
+                self._queue.put(AlignmentMessage(level="info", message=line, candidate=json_path))
+        if stderr:
+            for line in stderr.splitlines():
+                self._queue.put(AlignmentMessage(level="warning", message=line, candidate=json_path))
+        if return_code == 0:
+            self._queue.put(
+                AlignmentMessage(
+                    level="success",
+                    message=f"Utworzono {output_path.name}",
+                    candidate=json_path,
+                )
+            )
+        else:
+            self._queue.put(
+                AlignmentMessage(
+                    level="error",
+                    message=f"align.py zakończył się kodem {return_code}",
+                    candidate=json_path,
+                )
+            )
 
 
 def discover_alignment_candidates(output_dir: Path) -> List[AlignItem]:
@@ -23,4 +219,9 @@ def discover_alignment_candidates(output_dir: Path) -> List[AlignItem]:
     return candidates
 
 
-__all__ = ["AlignItem", "discover_alignment_candidates"]
+__all__ = [
+    "AlignItem",
+    "AlignmentMessage",
+    "AlignmentWorker",
+    "discover_alignment_candidates",
+]

--- a/ui/views/align.py
+++ b/ui/views/align.py
@@ -1,11 +1,14 @@
 """Alignment view."""
 from __future__ import annotations
 
+import queue
+from pathlib import Path
 from tkinter import messagebox
 
 from ui.bootstrap import ttk
-from ui.services.align import discover_alignment_candidates
+from ui.services.align import AlignItem, AlignmentMessage, AlignmentWorker, discover_alignment_candidates
 from ui.views.base import View
+from ui.widgets.textutil import END, create_text_widget
 
 
 class AlignView(View):
@@ -13,46 +16,151 @@ class AlignView(View):
     title = "Alignment"
 
     def build(self) -> None:
+        self._candidates: list[Path] = []
+        self._item_map: dict[str, Path] = {}
+        self._queue: "queue.Queue[AlignmentMessage]" = queue.Queue()
+        self._worker: AlignmentWorker | None = None
+        self.log_widget = None
+
         self.main_area.columnconfigure(0, weight=1)
         self.main_area.rowconfigure(0, weight=1)
+        self.main_area.rowconfigure(3, weight=1)
+
         ttk.Label(self.main_area, text="Pliki do alignu").grid(row=0, column=0, sticky="w")
-        self.tree = ttk.Treeview(
-            self.main_area,
-            columns=("file", "selected"),
-            show="headings",
-        )
+        self.tree = ttk.Treeview(self.main_area, columns=("file", "status"), show="headings")
         self.tree.heading("file", text="Plik")
-        self.tree.heading("selected", text="Wybrany")
-        self.tree.column("file", width=300)
-        self.tree.column("selected", width=80)
+        self.tree.heading("status", text="Status")
+        self.tree.column("file", width=320)
+        self.tree.column("status", width=140)
         self.tree.grid(row=1, column=0, sticky="nsew")
+
+        ttk.Label(self.main_area, text="Log").grid(row=2, column=0, sticky="w", pady=(8, 0))
+        self.log_widget = create_text_widget(self.main_area, height=12)
+        self.log_widget.grid(row=3, column=0, sticky="nsew")
 
         if self.right_panel is None:
             return
-        ttk.Label(self.right_panel, text="Opcje align", font=("TkDefaultFont", 12, "bold")).grid(row=0, column=0, sticky="w")
+
+        ttk.Label(self.right_panel, text="Opcje align", font=("TkDefaultFont", 12, "bold")).grid(
+            row=0, column=0, sticky="w"
+        )
         self.align_var = ttk.BooleanVar(value=True)
-        ttk.Checkbutton(self.right_panel, text="WHISPER_ALIGN", variable=self.align_var).grid(row=1, column=0, sticky="w")
-        ttk.Label(self.right_panel, text="PYANNOTE_AUTH_TOKEN").grid(row=2, column=0, sticky="w", pady=(12, 0))
+        ttk.Checkbutton(self.right_panel, text="WHISPER_ALIGN", variable=self.align_var).grid(
+            row=1, column=0, sticky="w"
+        )
+        ttk.Label(self.right_panel, text="PYANNOTE_AUTH_TOKEN").grid(
+            row=2, column=0, sticky="w", pady=(12, 0)
+        )
         self.token_var = ttk.StringVar(value="")
         ttk.Entry(self.right_panel, textvariable=self.token_var, show="*").grid(row=3, column=0, sticky="ew")
-        ttk.Button(self.right_panel, text="Start", command=self._start).grid(row=4, column=0, sticky="ew", pady=6)
-        ttk.Button(self.right_panel, text="Stop", command=self._stop).grid(row=5, column=0, sticky="ew")
+        self.start_button = ttk.Button(self.right_panel, text="Start", command=self._start)
+        self.start_button.grid(row=4, column=0, sticky="ew", pady=6)
+        self.stop_button = ttk.Button(self.right_panel, text="Stop", command=self._stop, state="disabled")
+        self.stop_button.grid(row=5, column=0, sticky="ew")
         self.right_panel.columnconfigure(0, weight=1)
 
     def on_show(self) -> None:
         self.refresh()
 
     def refresh(self) -> None:
+        self._candidates.clear()
+        self._item_map.clear()
         for item in self.tree.get_children():
             self.tree.delete(item)
-        for candidate in discover_alignment_candidates(self.state.config.output_dir):
-            self.tree.insert("", "end", values=(candidate.path.name, "✔" if candidate.selected else ""))
+        output_dir = self.state.config.output_dir
+        for candidate in discover_alignment_candidates(output_dir):
+            iid = str(candidate.path)
+            aligned = candidate.path.with_suffix(".aligned.json").exists()
+            self.tree.insert("", "end", iid=iid, values=(candidate.path.name, "✔" if aligned else ""))
+            self._item_map[iid] = candidate.path
+            self._candidates.append(candidate.path)
+        if self.log_widget:
+            self.log_widget.delete("1.0", END)
 
     def _start(self) -> None:
-        messagebox.showinfo("Align", "Stub: align start")
+        if not self.align_var.get():
+            messagebox.showinfo("Align", "Opcja WHISPER_ALIGN jest wyłączona.")
+            return
+        if self._worker and self._worker.is_running:
+            messagebox.showinfo("Align", "Proces align jest już uruchomiony.")
+            return
+        selected = self.tree.selection()
+        if selected:
+            paths = [self._item_map[item] for item in selected if item in self._item_map]
+        else:
+            paths = list(self._candidates)
+        if not paths:
+            messagebox.showwarning("Align", "Brak kandydatów do alignu.")
+            return
+        align_items = [AlignItem(path=path) for path in paths]
+        self._queue = queue.Queue()
+        self._worker = AlignmentWorker(
+            align_items,
+            recordings_dir=self.state.config.recordings_dir,
+            output_dir=self.state.config.output_dir,
+            queue_=self._queue,
+            diarization_token=self.token_var.get().strip() or None,
+        )
+        self._worker.start()
+        self.start_button.configure(state="disabled")
+        self.stop_button.configure(state="normal")
+        self._append_log("info", "Uruchomiono proces align.")
+        self.after(150, self._poll_queue)
 
     def _stop(self) -> None:
-        messagebox.showinfo("Align", "Stub: align stop")
+        if not self._worker:
+            return
+        self._worker.stop()
+        self._append_log("info", "Wysłano sygnał zatrzymania align.")
+
+    def _poll_queue(self) -> None:
+        while True:
+            try:
+                message = self._queue.get_nowait()
+            except queue.Empty:
+                break
+            self._handle_message(message)
+        if self._worker and self._worker.is_running:
+            self.after(200, self._poll_queue)
+        else:
+            self._worker = None
+            self.start_button.configure(state="normal")
+            self.stop_button.configure(state="disabled")
+
+    def _handle_message(self, message: AlignmentMessage) -> None:
+        if message.level == "state":
+            if message.message == "done":
+                self._append_log("info", "Zakończono align.")
+            elif message.message == "stopped":
+                self._append_log("warn", "Align zatrzymany przez użytkownika.")
+            return
+
+        candidate_path = message.candidate
+        if candidate_path is not None:
+            iid = str(candidate_path)
+            if message.level == "success":
+                self.tree.set(iid, "status", "✔")
+            elif message.level == "error":
+                self.tree.set(iid, "status", "✖")
+
+        normalized_level = {
+            "success": "info",
+            "warning": "warn",
+            "error": "error",
+        }.get(message.level, message.level)
+        suffix = f" ({candidate_path.name})" if candidate_path else ""
+        self._append_log(normalized_level, f"{message.message}{suffix}")
+
+    def _append_log(self, level: str, text: str) -> None:
+        if not self.log_widget:
+            return
+        prefix = {
+            "info": "[info]",
+            "warn": "[warn]",
+            "error": "[error]",
+        }.get(level, "[info]")
+        self.log_widget.insert(END, f"{prefix} {text}\n")
+        self.log_widget.see(END)
 
 
 __all__ = ["AlignView"]

--- a/ui/views/transcribe.py
+++ b/ui/views/transcribe.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from tkinter import messagebox
 from typing import Dict
 
 from ui.bootstrap import ttk
@@ -96,7 +97,14 @@ class TranscribeView(View):
         session_dir = self._detect_session_dir(config.recordings_dir)
         if session_dir:
             env["SESSION_DIR"] = str(session_dir)
-        self.task_manager.start(env, dry_run=dry_run)
+        try:
+            self.task_manager.start(env, dry_run=dry_run)
+        except RuntimeError as exc:
+            if self.log_widget:
+                self.log_widget.insert(END, f"\n[error] {exc}")
+                self.log_widget.see(END)
+            messagebox.showerror("Transkrypcja", str(exc))
+            return
         self.after(100, self._poll_logs)
         if self.log_widget:
             self.log_widget.insert(END, f"\n[info] Uruchomiono transkrypcję (dry_run={dry_run})")


### PR DESCRIPTION
## Summary
- add manifest validation utilities and hook them into the sessions view with user feedback
- enable exporting transcription artifacts from the results view and surface task errors in the transcribe view
- wire up the alignment view to execute align.py in the background with progress logging

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4d7c7a7908321a0516e7b6b216f30